### PR TITLE
add option to override 'pixel is inside'-test

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ module.exports = function sdf(array, opt) {
     var spread = number(opt && opt.spread, 1)
     var downscale = number(opt && opt.downscale, 1)
     
+    var testInside = opt.isInside || inside;
+    
     var width = array.shape[0],
         height = array.shape[1]
 
@@ -23,7 +25,7 @@ module.exports = function sdf(array, opt) {
         y = ~~( i / width )
         var idx = array.index(x, y, 0)
 
-        var bit = inside(array, x, y) ? 0xff : 0x00
+        var bit = testInside(array, x, y) ? 0xff : 0x00
         bitmap.set(x, y, 0, bit)
     }
 


### PR DESCRIPTION
a new option `isInside` can be used to specify a function that is called instead of the default `inside`-function to determine if the given coordinate is considered inside the shape. This can be useful for images that only vary in their opacity but are otherwise completely black. 

As this is the only place where the source-image is actually accessed it can also be used to support ndarrays with shapes like `[width, height, 1]`.

Example:

``` javascript

sourceImage = ndarray(imageData, [width, height, 4])
var output = sdf(sourceImage, { 
  isInside: function(array, x, y)  { 
    return array.get(x,y,3) > 128; 
  }
})

```
