### PR TITLE
Add grid, color, and alpha options

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,14 @@ PRs welcome. This could be split into more modules (generating a bit mask, compu
 image-sdf input.png [opt]
 
 Options:
-  -o, --output     output file                                    
-  -s, --spread     distance spread amount, default 1              
-  -d, --downscale  amount to downscale the output, default 1      
-  -c, --color      output color, accepts css strings, default #fff
-  -h               Show help                                      
+  -o, --output      output file
+  -s, --spread      distance spread amount, default 1
+  -d, --downscale   amount to downscale the output, default 1
+  -a, --alphaonly   Alpha only, if 1 then only look at alpha not RGB. default 0
+  -x, --gridwidth   Grid cell width in px. If present, SDFs will be generated within grid cells. default -1
+  -y, --gridheight  Grid cell height in px. If present, SDFs will be generated within grid cells. default -1
+  -c, --color       output color, accepts css strings. If it is "S" then it will use the same color replacing alpha, default #fff
+  -h                Show help
 ```
 
 Examples:
@@ -40,6 +43,7 @@ Examples:
 image-sdf input.png -c "rgb(128,255,20)" -s 10 -o output.png
 image-sdf input.png --spread 2 --downscale 2 > output.png
 image-sdf input.png --color black -o build/output.png
+image-sdf input.png --color S -o build/output.png -x 16 -y 16 -a 1
 ```
 
 The programmatic API may evolve into their own modules, i.e. for custom bitmasks.

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -8,8 +8,14 @@ var argv = require('yargs')
     .describe('s', 'distance spread amount, default 1')
     .alias('d', 'downscale')
     .describe('d', 'amount to downscale the output, default 1')
+    .alias('a', 'alphaonly')
+    .describe('a', 'Alpha only, if 1 then only look at alpha not RGB. default 0')
+    .alias('x', 'gridwidth')
+    .describe('x', 'Grid cell width in px. If present, SDFs will be generated within grid cells. default -1')
+    .alias('y', 'gridheight')
+    .describe('y', 'Grid cell height in px. If present, SDFs will be generated within grid cells. default -1')
     .alias('c', 'color')
-    .describe('c', 'output color, accepts css strings, default #fff')
+    .describe('c', 'output color, accepts css strings. If it is "S" then it will use the same color replacing alpha, default #fff')
     .help('h')
     .usage('image-sdf input.png [opt] > output.png')
     .argv
@@ -22,11 +28,17 @@ var generate = require('../image-sdf')
 
 var output = argv.o ? fs.createWriteStream(argv.o) : process.stdout
 var input = argv._[0]
-var rgb = argv.c ? getRgb(argv.c.trim()) : [0xff, 0xff, 0xff]
+var rgb = [0xff, 0xff, 0xff]
+if (argv.c) {
+    if (argv.c != "S")
+        rgb = getRgb(argv.c.trim())
+    else rgb = "S"
+}
 
 read(input, function(err, pixels) {
     if (err)
         throw err
-    var sdf = generate(pixels, { spread: argv.s, downscale: argv.d, color: rgb })
+    var dims = {x: argv.x ?? -1, y: argv.y ?? -1}
+    var sdf = generate(pixels, { spread: argv.s, downscale: argv.d, color: rgb, exclude: argv.a, grid:dims })
     save(sdf, 'png').pipe(output)
 })

--- a/image-sdf.js
+++ b/image-sdf.js
@@ -2,21 +2,29 @@ var ndarray = require('ndarray')
 var compute = require('./')
 
 module.exports = function(array, opt) {
-    var alpha = compute(array, opt)
-    var color = opt.color || [0xff, 0xff, 0xff]
+    var { output_distances , output_closest_colors } = compute(array, opt)
+    var color = opt.color || [0xff, 0xff, 0xff] 
+    var useTrueColor = opt.color === "S"
 
-    var width = alpha.shape[0],
-        height = alpha.shape[1]
+    var width = output_distances.shape[0],
+        height = output_distances.shape[1]
     var result = new Uint8ClampedArray(width*height*4)
     var output = ndarray(result, [width, height, 4])
     for (var i=0; i<width*height; i++) {
         var x = i % width,
             y = ~~( i / width )
-        var a = alpha.get(x, y, 0)
+        var a = output_distances.get(x, y, 0)
         var idx = output.index(x, y, 0)
-        result[idx+0] = color[0]
-        result[idx+1] = color[1]
-        result[idx+2] = color[2]
+        if (useTrueColor) {
+            result[idx+0] = output_closest_colors.get(x,y,0)
+            result[idx+1] = output_closest_colors.get(x,y,1)
+            result[idx+2] = output_closest_colors.get(x,y,2)
+        }
+        else {
+            result[idx+0] = color[0]
+            result[idx+1] = color[1]
+            result[idx+2] = color[2]
+        }
         result[idx+3] = a
     }
     return output

--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ var stride = 4
 module.exports = function sdf(array, opt) {
     var spread = number(opt && opt.spread, 1)
     var downscale = number(opt && opt.downscale, 1)
+    var excludeRGB = number(opt && opt.exclude, 0)
+    var grid = opt.grid
     
     var width = array.shape[0],
         height = array.shape[1]
@@ -23,22 +25,24 @@ module.exports = function sdf(array, opt) {
         y = ~~( i / width )
         var idx = array.index(x, y, 0)
 
-        var bit = inside(array, x, y) ? 0xff : 0x00
+        var bit = inside(array, x, y, excludeRGB) ? 0xff : 0x00
         bitmap.set(x, y, 0, bit)
     }
 
     var outWidth = Math.floor(width / downscale)
     var outHeight = Math.floor(height / downscale)
 
-    var data = new Uint8ClampedArray(outWidth*outHeight)
-    var output = ndarray(data, [outWidth, outHeight, 1])
-    compute(output, bitmap, width, height, spread, downscale)
+    var dist_data = new Uint8ClampedArray(outWidth*outHeight)
+    var output_distances = ndarray(dist_data, [outWidth, outHeight, 1])
+    var color_data = new Uint8ClampedArray(outWidth*outHeight*3)
+    var output_closest_colors = ndarray(color_data, [outWidth, outHeight, 3])
+    compute(output_distances, output_closest_colors, bitmap, array, width, height, spread, downscale, grid)
 
     pool.free(scratch)
-    return output
+    return { output_distances, output_closest_colors }
 }
 
-function compute(output, bitmap, width, height, spread, downscale) {
+function compute(output, closest_color_output, bitmap, pixels, width, height, spread, downscale, grid) {
     var outWidth = output.shape[0]
     var outHeight = output.shape[1]
 
@@ -47,27 +51,50 @@ function compute(output, bitmap, width, height, spread, downscale) {
             var centerX = Math.floor(x * downscale + downscale / 2)
             var centerY = Math.floor(y * downscale + downscale / 2)
 
-            var signedDistance = findSignedDistance(bitmap, 
+            var { signedDistance, closest} = findSignedDistance(bitmap,
                                     width, height,
-                                    centerX, centerY, spread)
+                                    centerX, centerY, spread,
+                                    grid)
             
             var alpha = 0.5 + 0.5 * (signedDistance / spread)
             alpha = Math.floor(clamp(alpha, 0, 1) * 0xff)
             output.set(x, y, 0, alpha)
+
+            var pixIdx = pixels.index(closest.x, closest.y, 0)
+            closest_color_output.set(x,y,0, pixels.data[pixIdx+0])
+            closest_color_output.set(x,y,1, pixels.data[pixIdx+1])
+            closest_color_output.set(x,y,2, pixels.data[pixIdx+2])
         }
     }
 }
 
-function findSignedDistance(bitmap, width, height, centerX, centerY, spread) {   
+function getCell(x, y, grid) {
+    if (grid.x > 0) x = Math.floor(x / grid.x)
+    if (grid.y > 0) y = Math.floor(y / grid.y)
+    return { x, y }
+}
+function findSignedDistance(bitmap, width, height, centerX, centerY, spread, grid) {
     var base = bitmap.get(centerX, centerY, 0)
+    var cell = { x: 0, y: 0, w: width-1, h: height-1}
+    if (grid.x > 0) {
+        cell.x = Math.floor(centerX / grid.x)
+        cell.w = Math.min(cell.w, (cell.x + 1)*grid.x)
+        cell.x *= grid.x
+    }
+    if (grid.y > 0) {
+        cell.y = Math.floor(centerY / grid.y)
+        cell.h = Math.min(cell.h, (cell.y + 1) * grid.y)
+        cell.y *= grid.y
+    }
     
     var delta = Math.ceil(spread)
-    var startX = Math.max(0, centerX - delta)
-    var endX  = Math.min(width - 1, centerX + delta)
-    var startY = Math.max(0, centerY - delta)
-    var endY = Math.min(height - 1, centerY + delta)
+    var startX = Math.max(cell.x, centerX - delta)
+    var endX  = Math.min(cell.w, centerX + delta)
+    var startY = Math.max(cell.y, centerY - delta)
+    var endY = Math.min(cell.h, centerY + delta)
 
     var closestSquareDist = delta * delta
+    var closestCoord = {x:centerX, y:centerY}
 
     for (var y = startY; y <= endY; ++y) {
         for (var x = startX; x <= endX; ++x) {
@@ -75,13 +102,17 @@ function findSignedDistance(bitmap, width, height, centerX, centerY, spread) {
                 var sqDist = squareDist(centerX, centerY, x, y)
                 if (sqDist < closestSquareDist) {
                     closestSquareDist = sqDist
+                    if (!base) {
+                        closestCoord = {x,y}
+                    }
                 }
             }
         }
     }
     
     var closestDist = Math.sqrt(closestSquareDist)
-    return (base===0xff ? 1 : -1) * Math.min(closestDist, spread)
+    var out = (base===0xff ? 1 : -1) * Math.min(closestDist, spread)
+    return {signedDistance:out, closest:closestCoord}
 }
 
 function squareDist(x1, y1, x2, y2) {
@@ -90,10 +121,10 @@ function squareDist(x1, y1, x2, y2) {
     return dx*dx + dy*dy
 }
 
-function inside(array, x, y) {
+function inside(array, x, y, excludeRGB) {
     var idx = array.index(x, y, 0)
     var data = array.data
     var t = 128
     return data[idx+3]>t && 
-        (data[idx+0]>t || data[idx+1]>t || data[idx+2]>t)        
+        (excludeRGB>0 || data[idx+0]>t || data[idx+1]>t || data[idx+2]>t)
 }


### PR DESCRIPTION
I use this for some spritesheet graphics. I've added a few options to facilitate that which may be useful to others:
 - Grid: parameters `x` and `y` specify the size in pixels of grid cells. SDF calculations will be restricted to within cell borders
 - Preserve color: If the `c` parameter is `S`, it will use the "same" color in the output image rather than just white or any static color. For pixels considered "outside", it will use the color from the closest "inside" pixel
 - Alpha-only: If the `a` parameter is 1, then the "inside" function will ignore the RGB of the pixel and only look at the alpha value